### PR TITLE
nava11y: export raw before/after style snapshots for SC 2.4.7/2.4.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 node_modules/
 nava11y/node_modules/
-# nava11y/ is a vendored copy of the NavA11y sibling repo — do not edit it here
+# nava11y/ is a vendored copy of NavA11y. Edits allowed only for `nava11y:` prefixed
+# commits that get cherry-picked upstream to jaf107/NavA11y. Do not commit lockfiles
+# or build artifacts generated locally.
+nava11y/package-lock.json
+nava11y/pnpm-lock.yaml
 nava11y/reports/
 .env
 experiments/results/

--- a/RESEARCH_QUESTIONS.md
+++ b/RESEARCH_QUESTIONS.md
@@ -1,0 +1,97 @@
+# Research Questions — RepairA11y
+
+Five RQs derived from issues #14, #18, #19, #20, #21.
+
+## RQ1 — Effectiveness (issue #18)
+
+**Question:** How effective are rule-based and LLM-based generators at resolving WCAG 2.4 focus-behavior violations across controlled (D_d) and production (D_r) datasets?
+
+**Design:** Full repair loop on D_d (22 pages) + D_r (27 sites), both generators, all 5 SCs.
+
+**Metric:** Per-SC resolution rate, per-dataset totals. Expect D_r harder.
+
+**Output:** `experiments/results/rq1.json` + markdown table.
+
+---
+
+## RQ2 — Runtime evidence ablation (issue #14) — CORE CLAIM
+
+**Question:** Do LLM repair systems receiving runtime evidence (E3/E4) produce better patches than systems receiving only static evidence (E1/E2)?
+
+**Design:** D_d × LLM generator × {E1, E2, E3, E4} × 3 seeds. Same model, pinned temperature.
+
+**Evidence levels:**
+- E1: outerHTML + full-page screenshot
+- E2: E1 + WCAG technique text
+- E3: E2 + runtime slice (style snapshots, contrast, obscurer, tab sequence)
+- E4: E3 + annotated element-crop screenshot
+
+**Metric:** Mean resolution rate ± std per level, per SC.
+
+**Output:** `experiments/results/rq2.json` + paper-ready table.
+
+---
+
+## RQ3 — Loop iteration impact (issue #19)
+
+**Question:** Does iterative re-prompting improve resolution, or is single-shot enough?
+
+**Design:** D_r × LLM generator × E3 × maxIterations ∈ {1, 3, 5}.
+
+**Metric:** Marginal resolution gain per added iteration. Diminishing-returns curve (or absence).
+
+**Output:** Iteration-vs-resolution plot.
+
+---
+
+## RQ4 — Regression detection (issue #20)
+
+**Question:** Do successful repairs introduce new WCAG violations or visual breakage?
+
+**Design:** Reuse RQ1 patches. SSIM threshold sweep {0.90, 0.95, 0.98} + new-violation counts.
+
+**Metric:** Regression rate per generator. Claim-ready: "X% of patches introduce no new violations AND SSIM > 0.95."
+
+**Output:** Per-generator regression table.
+
+---
+
+## RQ5 — Developer utility study (issue #21)
+
+**Question:** Do human developers accept generated patches as correct, minimal, and well-rationalized?
+
+**Design:** 20 patches sampled across SCs + generators. N≈20 devs rate Accept / Accept-with-edits / Reject.
+
+**Rubric:** correctness · minimality · rationale clarity.
+
+**Metric:** Inter-rater agreement (Cohen's κ or Fleiss' κ). Pass rate vs manual-accept rate side-by-side.
+
+**Output:** `experiments/results/rq5.json`. Addresses oracle-overfit threat.
+
+---
+
+## Dependency map
+
+```
+RQ1 ──┬── needs all 5 SC generators (rule + LLM)
+      └── feeds RQ4 (regression reuses patches)
+
+RQ2 ── only SC 2.4.13 LLM — earliest paper-able result
+       CORE CLAIM of thesis chapter 2
+
+RQ3 ── after RQ1 infra in place, LLM only
+
+RQ4 ── reuses RQ1 artifacts
+
+RQ5 ── last, needs finished patches across RQs
+```
+
+## Positioning per RQ
+
+| RQ | Competitor baseline | Claim |
+|----|---------------------|-------|
+| RQ1 | GenA11y (0% recall on 2.4.3/2.4.7), AccessGuru (axe-only) | First tool covering focus-behavior SCs end-to-end |
+| RQ2 | Static-evidence LLM repair (E1/E2 ≈ GenA11y, DesignRepair) | Runtime evidence = better patches |
+| RQ3 | AccessGuru loop structure | Iterations do real work (or don't) |
+| RQ4 | Prior work reports resolution only, rarely regression | Minimal side-effect claim |
+| RQ5 | Oracle-only pass rates (everyone else) | Human-validated accept rate |

--- a/nava11y/README.md
+++ b/nava11y/README.md
@@ -58,6 +58,31 @@ Reports are generated in `reports/<site>/`:
 - `index.html` — interactive report with per-SC filtering and annotated screenshots
 - `results.json` — machine-readable results with full evidence
 
+### Evidence schema — style snapshots (SC 2.4.7 / 2.4.13)
+
+For element-level records with `sc: "2.4.7"` or `sc: "2.4.13"` and `result: "FAIL" | "REVIEW"`, `evidence.styleSnapshots` contains the raw computed-style snapshots captured before and after focus:
+
+```json
+"evidence": {
+  "styleSnapshots": {
+    "before": {
+      "outlineStyle": "none", "outlineWidth": 0, "outlineColor": "rgb(...)", "outlineOffset": 0,
+      "boxShadow": "none",
+      "borderTopWidth": 0, "borderTopColor": "rgb(...)", "borderColor": "rgb(...)",
+      "backgroundColor": "rgb(...)", "color": "rgb(...)", "opacity": 1,
+      "transform": "none", "visibility": "visible", "display": "inline-block",
+      "textDecoration": "none", "textDecorationColor": "rgb(...)",
+      "fontWeight": "400", "position": "static", "zIndex": "auto",
+      "transition": "all 0s ease 0s", "filter": "none",
+      "clip": "auto", "clipPath": "none"
+    },
+    "after": { ...same shape, post-focus values... }
+  }
+}
+```
+
+Absent on PASS records and on other SCs. Consumers should treat the field as optional for forward compat with older reports.
+
 ## Datasets
 
 ### D_d — Focus Behavior Dataset (Synthetic, Labeled)

--- a/nava11y/explorer/runner.js
+++ b/nava11y/explorer/runner.js
@@ -496,9 +496,22 @@ async function run(url) {
             );
           }
 
+          // Attach raw style snapshots to evidence for focus-appearance SCs
+          // (consumed by downstream repair tooling; preserves backwards compat).
+          const attachSnapshots =
+            (check.id === "2.4.7" || check.id === "2.4.13") &&
+            (result.result === "FAIL" || result.result === "REVIEW");
+          const evidenceWithSnapshots = attachSnapshots
+            ? {
+                ...(result.evidence || {}),
+                styleSnapshots: { before: beforeStyle, after: afterStyle },
+              }
+            : result.evidence;
+
           // Push result for this check
           results.push({
             ...result,
+            ...(attachSnapshots && { evidence: evidenceWithSnapshots }),
             ...(result.result === "FAIL" && { id: crypto.randomUUID() }),
             element: elMetadata,
             screenshot: screenshot,

--- a/nava11y/instrumentation/index.js
+++ b/nava11y/instrumentation/index.js
@@ -44,10 +44,18 @@ window.__snapshotComputedStyle = function (el) {
     visibility: cs.visibility,
     display: cs.display,
 
+    textDecoration: cs.textDecoration,
     textDecorationLine: cs.textDecorationLine,
     textDecorationStyle: cs.textDecorationStyle,
     textDecorationColor: cs.textDecorationColor,
     textDecorationThickness: cs.textDecorationThickness,
+
+    fontWeight: cs.fontWeight,
+    position: cs.position,
+    zIndex: cs.zIndex,
+    transition: cs.transition,
+    clip: cs.clip,
+    clipPath: cs.clipPath,
 
     filter: cs.filter,
     isFocusVisible: el.matches ? el.matches(":focus-visible") : false,


### PR DESCRIPTION
## Summary

- Adds 7 previously-omitted CSS properties to NavA11y's focus-state snapshot so it covers the full 22-property set the issue spec requires.
- Surfaces the snapshots into `results.json` under `evidence.styleSnapshots.{before, after}` — only for SC 2.4.7 / 2.4.13 FAIL/REVIEW element-level records, strictly additive for existing consumers.
- Documents the new field shape in the NavA11y README.

This unblocks RepairA11y Stage 2 (evidence packager, issue #11) and the detector wrapper normalization (issue #4). The change itself lives in the vendored `nava11y/` copy under the `nava11y:` prefix and has been cherry-picked to `jaf107/NavA11y` upstream in [jaf107/NavA11y#1](https://github.com/jaf107/NavA11y/pull/1) per CLAUDE.md policy.

## Test plan

- [x] `node run-check.js --file dataset/focus-behavior-dataset/tests/focus-appearance-outline-insufficient-width.html` — the 2.4.13 FAIL record carries `evidence.styleSnapshots.before` and `.after` populated with all 22 CSS props (outline/border/text-decoration/fontWeight/position/zIndex/transition/clip/clipPath/filter/…).
- [x] Same run — 2.4.7 PASS and 2.4.11 PASS records have no `styleSnapshots` key (backwards compat preserved).
- [x] Upstream cherry-pick PR against jaf107/NavA11y opened: jaf107/NavA11y#1.

Closes #1