### PR TITLE
nava11y: export per-obscurer details for SC 2.4.11 / 2.4.12

### DIFF
--- a/nava11y/README.md
+++ b/nava11y/README.md
@@ -83,6 +83,27 @@ For element-level records with `sc: "2.4.7"` or `sc: "2.4.13"` and `result: "FAI
 
 Absent on PASS records and on other SCs. Consumers should treat the field as optional for forward compat with older reports.
 
+### Evidence schema — obscurer details (SC 2.4.11 / 2.4.12)
+
+For element-level records with `sc: "2.4.11"` or `sc: "2.4.12"`, `evidence.obscurers` lists each distinct element detected as obscuring the focused target, with full positional + stacking context needed by repair tooling. The pre-existing `evidence.obscuredBy` array (selector strings only) is retained for backwards compatibility.
+
+```json
+"evidence": {
+  "obscuredRatio": 0.24,
+  "obscuredBy": ["header.site-header"],
+  "obscurers": [
+    {
+      "selector": "header.site-header",
+      "bbox": { "top": 0, "left": 0, "width": 1280, "height": 80 },
+      "position": "fixed",
+      "zIndex": 1000
+    }
+  ]
+}
+```
+
+`zIndex` is the string `"auto"` when the computed value is `auto`, otherwise an integer. `obscurers` is an empty array on PASS records with no detected obscurer and on REVIEW records with missing obscuration data.
+
 ## Datasets
 
 ### D_d — Focus Behavior Dataset (Synthetic, Labeled)

--- a/nava11y/checks/2_4_11_focus_not_obscured_minimum.js
+++ b/nava11y/checks/2_4_11_focus_not_obscured_minimum.js
@@ -25,7 +25,8 @@ export function checkFocusNotObscuredMinimum(trace, config = {}) {
       reason: `Focused element is entirely hidden by other content (obscured by: ${(obscuration.obscuredBy || []).join(', ')})`,
       evidence: {
         obscuredRatio: obscuration.obscuredRatio,
-        obscuredBy: obscuration.obscuredBy
+        obscuredBy: obscuration.obscuredBy,
+        obscurers: obscuration.obscurers || []
       },
       sc: '2.4.11'
     };
@@ -37,7 +38,8 @@ export function checkFocusNotObscuredMinimum(trace, config = {}) {
       reason: `Focused element is partially obscured but still visible (${(obscuration.obscuredRatio * 100).toFixed(1)}% hidden)`,
       evidence: {
         obscuredRatio: obscuration.obscuredRatio,
-        obscuredBy: obscuration.obscuredBy
+        obscuredBy: obscuration.obscuredBy,
+        obscurers: obscuration.obscurers || []
       },
       sc: '2.4.11'
     };

--- a/nava11y/checks/2_4_12_focus_not_obscured_enhanced.js
+++ b/nava11y/checks/2_4_12_focus_not_obscured_enhanced.js
@@ -26,7 +26,8 @@ export function checkFocusNotObscuredEnhanced(trace, config = {}) {
       reason: `Focused element is obscured by other content (${(obscuration.obscuredRatio * 100).toFixed(1)}% hidden. Obscured by: ${(obscuration.obscuredBy || []).join(', ')})`,
       evidence: {
         obscuredRatio: obscuration.obscuredRatio,
-        obscuredBy: obscuration.obscuredBy
+        obscuredBy: obscuration.obscuredBy,
+        obscurers: obscuration.obscurers || []
       },
       sc: '2.4.12'
     };

--- a/nava11y/instrumentation/index.js
+++ b/nava11y/instrumentation/index.js
@@ -91,6 +91,8 @@ window.__getObscurationData = function (el) {
       obscuredRatio: 0,
       isFullyObscured: false,
       isPartiallyObscured: false,
+      obscuredBy: [],
+      obscurers: [],
     };
 
   const rect = el.getBoundingClientRect();
@@ -99,6 +101,8 @@ window.__getObscurationData = function (el) {
       obscuredRatio: 1,
       isFullyObscured: true,
       isPartiallyObscured: true,
+      obscuredBy: [],
+      obscurers: [],
     };
   }
 
@@ -121,6 +125,8 @@ window.__getObscurationData = function (el) {
       obscuredRatio: 1,
       isFullyObscured: true,
       isPartiallyObscured: true,
+      obscuredBy: [],
+      obscurers: [],
     };
   }
 
@@ -132,7 +138,10 @@ window.__getObscurationData = function (el) {
   const stepX = visibleWidth / (pointsX + 1);
   const stepY = visibleHeight / (pointsY + 1);
 
-  const obscuringElements = new Set();
+  // Track each distinct obscurer once, keyed by its computed selector.
+  // Value carries bbox + position + zIndex so downstream tooling can reason
+  // about sticky headers / overlays without re-querying the DOM.
+  const obscurers = new Map();
 
   for (let i = 1; i <= pointsX; i++) {
     for (let j = 1; j <= pointsY; j++) {
@@ -174,16 +183,34 @@ window.__getObscurationData = function (el) {
         ) {
           isObscuredAtPoint = true;
 
+          let selector;
           if (topEl.id) {
-            obscuringElements.add("#" + topEl.id);
+            selector = "#" + topEl.id;
           } else if (topEl.className && typeof topEl.className === "string") {
-            obscuringElements.add(
+            selector =
               topEl.tagName.toLowerCase() +
-                "." +
-                topEl.className.split(" ").join("."),
-            );
+              "." +
+              topEl.className.split(" ").join(".");
           } else {
-            obscuringElements.add(topEl.tagName.toLowerCase());
+            selector = topEl.tagName.toLowerCase();
+          }
+
+          if (!obscurers.has(selector)) {
+            const oRect = topEl.getBoundingClientRect();
+            const rawZ = style.zIndex;
+            const zIndex =
+              rawZ === "auto" || rawZ === "" ? "auto" : parseInt(rawZ, 10) || 0;
+            obscurers.set(selector, {
+              selector,
+              bbox: {
+                top: oRect.top,
+                left: oRect.left,
+                width: oRect.width,
+                height: oRect.height,
+              },
+              position: style.position,
+              zIndex,
+            });
           }
           break;
         }
@@ -203,7 +230,8 @@ window.__getObscurationData = function (el) {
     obscuredRatio,
     isPartiallyObscured: obscuredRatio > 0,
     isFullyObscured,
-    obscuredBy: Array.from(obscuringElements),
+    obscuredBy: Array.from(obscurers.keys()),
+    obscurers: Array.from(obscurers.values()),
   };
 };
 


### PR DESCRIPTION
## Summary

- Captures `bbox`, `position`, and `zIndex` for each obscuring element the instrumentation detects, surfaces them as `evidence.obscurers[]` on SC 2.4.11 / 2.4.12 FAIL and partially-obscured PASS records.
- Leaves `evidence.obscuredBy[]` (selector strings) untouched for backwards compat.
- Makes the empty-/error-path returns include `obscuredBy: []` and `obscurers: []` for shape stability.

Unblocks the M6 rule-based obscuration repair generator (issue #16) and the Stage 2 evidence packager (issue #11). Upstream cherry-pick opened at [jaf107/NavA11y#2](https://github.com/jaf107/NavA11y/pull/2).

## Test plan

- [x] `node run-check.js --file nava11y/dataset/focus-behavior-dataset/tests/focus-obscured-by-cookie-banner.html` — 2.4.11 and 2.4.12 FAIL records carry `evidence.obscurers = [{ selector: "div.cookie-banner", bbox: {...}, position: "fixed", zIndex: 200 }]`.
- [x] Same run — `evidence.obscuredBy = ["div.cookie-banner"]` still present on both records (no consumer breakage).
- [x] Empty-path early returns include `obscuredBy: []` and `obscurers: []`.

Closes #2