### PR TITLE
nava11y: export positive tabindex elements for SC 2.4.3

### DIFF
--- a/nava11y/README.md
+++ b/nava11y/README.md
@@ -104,6 +104,19 @@ For element-level records with `sc: "2.4.11"` or `sc: "2.4.12"`, `evidence.obscu
 
 `zIndex` is the string `"auto"` when the computed value is `auto`, otherwise an integer. `obscurers` is an empty array on PASS records with no detected obscurer and on REVIEW records with missing obscuration data.
 
+### Evidence schema — positive tabindex elements (SC 2.4.3)
+
+Page-level records for SC 2.4.3 with `result: "FAIL"` or `result: "REVIEW"` expose a top-level `evidence.positiveTabindexElements[]` array listing every element flagged under W3C Failure Technique F44 (positive `tabindex`). Each entry carries the element's selector, effective `tabIndex`, `tagName`, and its on-page `position` (top / left from `getBoundingClientRect()`), enabling downstream consumers to localize and remediate each offender without replaying the page.
+
+```json
+"evidence": {
+  "positiveTabindexElements": [
+    { "selector": "#save-btn", "tabIndex": 3, "tagName": "button", "position": { "top": 120, "left": 800 } }
+  ]
+}
+```
+
+Skip links (anchors targeting `#…` with conventional class/id patterns) are exempt and therefore excluded from this array.
 ## Datasets
 
 ### D_d — Focus Behavior Dataset (Synthetic, Labeled)

--- a/nava11y/checks/2_4_3_focus_order.js
+++ b/nava11y/checks/2_4_3_focus_order.js
@@ -81,6 +81,10 @@ function detectPositiveTabindexViolations(elements) {
       selector: el.selector,
       tabIndex: el.tabIndex,
       tagName: el.tagName,
+      position: {
+        top: el.bbox?.top ?? null,
+        left: el.bbox?.left ?? null,
+      },
     })),
     count: positiveTabIndexElements.length,
     severity: "high",
@@ -337,6 +341,9 @@ export function checkFocusOrder(pageData, config = {}) {
     (v) => v.severity === "medium",
   );
 
+  const positiveTabindexElements =
+    violations.find((v) => v.type === "positive-tabindex")?.elements || [];
+
   if (highSeverityViolations.length > 0) {
     return {
       result: "FAIL",
@@ -348,6 +355,7 @@ export function checkFocusOrder(pageData, config = {}) {
           tabIndex: el.tabIndex,
           position: { top: el.bbox?.top, left: el.bbox?.left },
         })),
+        positiveTabindexElements,
         summary: {
           totalFocusable: tabSequence.length,
           positiveTabindex:
@@ -371,6 +379,7 @@ export function checkFocusOrder(pageData, config = {}) {
           tabIndex: el.tabIndex,
           position: { top: el.bbox?.top, left: el.bbox?.left },
         })),
+        positiveTabindexElements,
         summary: {
           totalFocusable: tabSequence.length,
           orderDivergence: orderDivergence.toFixed(2),


### PR DESCRIPTION
## Summary

- `detectPositiveTabindexViolations()` in `nava11y/checks/2_4_3_focus_order.js` now enriches each offending element with `position: { top, left }` from its bounding rect.
- The 2.4.3 page-level check surfaces the enriched list as `evidence.positiveTabindexElements[]` on FAIL and REVIEW results, so downstream consumers (RepairA11y Stage 2 packager) can localize every F44 offender directly from `results.json`.
- README updated with the new evidence schema section.

Part of M1-Detector Track B (upstream NavA11y field additions). Companion cherry-pick PR will be opened against `jaf107/NavA11y`.

## Test plan

- [x] Smoke test on D_d fixture `keyboard-access-tabindex-greater-than-0.html` — regenerated `results.json` has `evidence.positiveTabindexElements[0] = { selector: "html > body > main > a", tabIndex: 5, tagName: "a", position: { top: 79.875, left: 8 } }`.
- [x] Backwards-compat — existing `evidence.violations[]` and `evidence.tabSequence[]` shapes unchanged.
- [x] Skip-link exemption (`isSkipLink`) still excludes `a[href^="#"]` anchors with skip-* selectors.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)