### PR TITLE
feat(schema): typed patch schema + 3 ground-truth patches

### DIFF
--- a/ground-truth/sc-2.4.11-focus-obscured-by-fixed-footer.json
+++ b/ground-truth/sc-2.4.11-focus-obscured-by-fixed-footer.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "nava11y/dataset/focus-behavior-dataset/tests/focus-obscured-by-fixed-footer.html",
+  "sc": "2.4.11",
+  "patch": {
+    "patch_type": "css_inject",
+    "target_selector": "button.footer-btn",
+    "payload": {
+      "rule": ".footer-btn { z-index: 150; }"
+    },
+    "rationale": "The focused button (z-index: 50, position: fixed) is visually covered by the fixed footer (z-index: 100). Raising the button's z-index to 150 places it above the footer, ensuring the focused element is not obscured (SC 2.4.11 Minimum). The fixed-footer stacking context is the only obscurer detected.",
+    "wcag_technique_cited": null
+  }
+}

--- a/ground-truth/sc-2.4.13-focus-appearance-outline-contrast.json
+++ b/ground-truth/sc-2.4.13-focus-appearance-outline-contrast.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "nava11y/dataset/focus-behavior-dataset/tests/focus-appearance-outline-insufficient-contrast.html",
+  "sc": "2.4.13",
+  "patch": {
+    "patch_type": "css_inject",
+    "target_selector": "button.aaa-outline",
+    "payload": {
+      "rule": "button.aaa-outline:focus { outline-color: #767676; }"
+    },
+    "rationale": "The existing :focus rule uses outline-color #999 (2.85:1 contrast against white #fff), below the SC 2.4.13 minimum of 3:1. Replacing with #767676 achieves 4.54:1 contrast while preserving the 2px solid outline width and focus-indicator area.",
+    "wcag_technique_cited": null
+  }
+}

--- a/ground-truth/sc-2.4.3-positive-tabindex.json
+++ b/ground-truth/sc-2.4.3-positive-tabindex.json
@@ -1,0 +1,14 @@
+{
+  "fixture": "nava11y/dataset/focus-behavior-dataset/tests/keyboard-access-tabindex-greater-than-0.html",
+  "sc": "2.4.3",
+  "patch": {
+    "patch_type": "attr_set",
+    "target_selector": "a[tabindex='5']",
+    "payload": {
+      "attribute": "tabindex",
+      "value": "0"
+    },
+    "rationale": "A tabindex value > 0 (here: 5) inserts the element ahead of all tabindex=0 elements in the tab sequence, violating natural DOM order. Setting tabindex to 0 restores the element's position in the natural tab sequence without removing keyboard reachability.",
+    "wcag_technique_cited": "F44"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "playwright": "^1.58.0"
       },
       "devDependencies": {
+        "ajv": "^8.18.0",
         "vitest": "^2.1.0"
       },
       "engines": {
@@ -885,6 +886,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1026,6 +1044,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1039,6 +1081,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -1164,6 +1213,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "playwright": "^1.58.0"
   },
   "devDependencies": {
+    "ajv": "^8.18.0",
     "vitest": "^2.1.0"
   }
 }

--- a/src/schemas/patch.schema.json
+++ b/src/schemas/patch.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "repaira11y/patch",
+  "title": "RepairA11y Typed Patch",
+  "description": "A single typed repair action produced by a generator and applied by the patch applier.",
+  "oneOf": [
+    { "$ref": "#/definitions/css_inject" },
+    { "$ref": "#/definitions/attr_set" },
+    { "$ref": "#/definitions/dom_reorder" },
+    { "$ref": "#/definitions/style_override" }
+  ],
+  "definitions": {
+    "common_fields": {
+      "type": "object",
+      "required": ["patch_type", "target_selector", "payload", "rationale", "wcag_technique_cited"],
+      "properties": {
+        "target_selector": {
+          "type": "string",
+          "minLength": 1,
+          "description": "CSS selector identifying the element to repair."
+        },
+        "rationale": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable explanation of why this patch fixes the violation."
+        },
+        "wcag_technique_cited": {
+          "description": "Relevant W3C technique or failure identifier, or null.",
+          "oneOf": [
+            { "type": "null" },
+            { "type": "string", "enum": ["C15", "C27", "C40", "F44", "F78", "G1"] }
+          ]
+        }
+      }
+    },
+    "css_inject": {
+      "allOf": [
+        { "$ref": "#/definitions/common_fields" },
+        {
+          "properties": {
+            "patch_type": { "type": "string", "const": "css_inject" },
+            "payload": {
+              "type": "object",
+              "required": ["rule"],
+              "properties": {
+                "rule": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "A complete CSS rule string to inject into a <style> block."
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["patch_type"]
+        }
+      ]
+    },
+    "attr_set": {
+      "allOf": [
+        { "$ref": "#/definitions/common_fields" },
+        {
+          "properties": {
+            "patch_type": { "type": "string", "const": "attr_set" },
+            "payload": {
+              "type": "object",
+              "required": ["attribute", "value"],
+              "properties": {
+                "attribute": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "HTML attribute name to set on target_selector."
+                },
+                "value": {
+                  "type": ["string", "null"],
+                  "description": "New attribute value, or null to remove the attribute."
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["patch_type"]
+        }
+      ]
+    },
+    "dom_reorder": {
+      "allOf": [
+        { "$ref": "#/definitions/common_fields" },
+        {
+          "properties": {
+            "patch_type": { "type": "string", "const": "dom_reorder" },
+            "payload": {
+              "type": "object",
+              "required": ["parent_selector", "insert_before_selector"],
+              "properties": {
+                "parent_selector": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "CSS selector of the new parent element."
+                },
+                "insert_before_selector": {
+                  "type": ["string", "null"],
+                  "description": "Move target before this sibling, or null to append last."
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["patch_type"]
+        }
+      ]
+    },
+    "style_override": {
+      "allOf": [
+        { "$ref": "#/definitions/common_fields" },
+        {
+          "properties": {
+            "patch_type": { "type": "string", "const": "style_override" },
+            "payload": {
+              "type": "object",
+              "required": ["property", "value"],
+              "properties": {
+                "property": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "CSS property name (camelCase or kebab-case)."
+                },
+                "value": {
+                  "type": "string",
+                  "description": "CSS property value to apply via element.style."
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": ["patch_type"]
+        }
+      ]
+    }
+  }
+}

--- a/tests/schemas/patch.test.js
+++ b/tests/schemas/patch.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import Ajv from "ajv";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..");
+
+function load(relPath) {
+  return JSON.parse(readFileSync(join(repoRoot, relPath), "utf8"));
+}
+
+const schema = load("src/schemas/patch.schema.json");
+const GROUND_TRUTH = [
+  "ground-truth/sc-2.4.13-focus-appearance-outline-contrast.json",
+  "ground-truth/sc-2.4.11-focus-obscured-by-fixed-footer.json",
+  "ground-truth/sc-2.4.3-positive-tabindex.json",
+];
+
+let validate;
+beforeAll(() => {
+  const ajv = new Ajv({ strict: false });
+  validate = ajv.compile(schema);
+});
+
+describe("patch schema — ground-truth cases", () => {
+  for (const relPath of GROUND_TRUTH) {
+    it(`validates ${relPath}`, () => {
+      const { patch } = load(relPath);
+      const ok = validate(patch);
+      expect(ok, JSON.stringify(validate.errors, null, 2)).toBe(true);
+    });
+  }
+});
+
+describe("patch schema — invalid cases rejected", () => {
+  it("rejects unknown patch_type", () => {
+    const bad = {
+      patch_type: "teleport",
+      target_selector: "button",
+      payload: {},
+      rationale: "x",
+      wcag_technique_cited: null,
+    };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects css_inject missing rule in payload", () => {
+    const bad = {
+      patch_type: "css_inject",
+      target_selector: "button",
+      payload: {},
+      rationale: "x",
+      wcag_technique_cited: null,
+    };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects attr_set missing attribute in payload", () => {
+    const bad = {
+      patch_type: "attr_set",
+      target_selector: "button",
+      payload: { value: "0" },
+      rationale: "x",
+      wcag_technique_cited: null,
+    };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects unknown wcag_technique_cited value", () => {
+    const bad = {
+      patch_type: "css_inject",
+      target_selector: "button",
+      payload: { rule: "button:focus { outline: 2px solid #000; }" },
+      rationale: "x",
+      wcag_technique_cited: "BOGUS99",
+    };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects missing required top-level field", () => {
+    const bad = {
+      patch_type: "css_inject",
+      payload: { rule: "button:focus { outline: 2px solid #000; }" },
+      rationale: "x",
+      wcag_technique_cited: null,
+    };
+    expect(validate(bad)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/schemas/patch.schema.json` — JSON Schema (draft-07) with discriminated-union validation for all four patch types (`css_inject`, `attr_set`, `dom_reorder`, `style_override`)
- Hand-authors one ground-truth patch per target SC in `ground-truth/`:
  - **SC 2.4.13** — `css_inject` raising outline-color from `#999` (2.85:1 contrast) to `#767676` (4.54:1)
  - **SC 2.4.11** — `css_inject` raising `z-index` of `.footer-btn` above the fixed footer
  - **SC 2.4.3** — `attr_set` replacing `tabindex=5` with `tabindex=0` (F44)
- `tests/schemas/patch.test.js` validates all 3 ground-truth patches against the schema and confirms 5 invalid inputs are rejected (39 tests total, all passing)

Closes #5, Closes #6

## Test plan

- [x] `npm test` → 39/39 passing (31 existing + 8 new schema tests)
- [x] Ground-truth patches all validate against `patch.schema.json` via Ajv
- [x] Invalid patch shapes (unknown `patch_type`, missing payload fields, unknown WCAG technique) correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)